### PR TITLE
Add Django REST framework

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -46,6 +46,7 @@ THIRD_PARTY_APPS = (
     'allauth',  # registration
     'allauth.account',  # registration
     'allauth.socialaccount',  # registration
+    'rest_framework',  # REST API
 )
 
 # Apps specific for this project go here.
@@ -245,6 +246,12 @@ LOGIN_URL = 'account_login'
 # SLUGLIFIER
 AUTOSLUG_SLUGIFY_FUNCTION = 'slugify.slugify'
 
-
 # Location of root django.contrib.admin URL, use {% url 'admin:index' %}
 ADMIN_URL = r'^admin/'
+
+# REST API
+REST_FRAMEWORK = {
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.DjangoModelPermissions'
+    ]
+}

--- a/config/urls.py
+++ b/config/urls.py
@@ -20,7 +20,7 @@ urlpatterns = [
     url(r'^accounts/', include('allauth.urls')),
 
     # Your stuff: custom urls includes go here
-
+    url(r'^api/', include("foosball.api.urls", namespace="api")),
 
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 

--- a/foosball/api/urls.py
+++ b/foosball/api/urls.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from django.conf.urls import url, include
+from rest_framework import routers
+
+from foosball.api.views import UserViewSet
+
+
+router = routers.DefaultRouter()
+router.register(r'users', UserViewSet)
+
+
+urlpatterns = [
+    url(r'^', include(router.urls)),
+    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
+]

--- a/foosball/api/views.py
+++ b/foosball/api/views.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from rest_framework import serializers, viewsets
+
+from foosball.users.models import User
+
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ('username', 'email', 'is_staff')
+
+
+class UserViewSet(viewsets.ModelViewSet):
+    queryset = User.objects.all()
+    serializer_class = UserSerializer

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -40,3 +40,6 @@ pytz==2015.7
 # Redis support
 django-redis==4.3.0
 redis>=2.10.0
+
+# REST API
+djangorestframework==3.3.2


### PR DESCRIPTION
Add foosball.api module with a simple API route for the User model (which should definitely be locked down).

We could build the rest endpoints to log scores using REST framework.

![selection_438](https://cloud.githubusercontent.com/assets/1174866/13470661/e5462a90-e0b5-11e5-8ac2-ac50b1522860.png)
