### PR TITLE
Server Users REST API as read-only

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -262,6 +262,7 @@ ADMIN_URL = r'^admin/'
 # REST API
 REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.DjangoModelPermissions'
+        'rest_framework.permissions.IsAuthenticated',
+        'rest_framework.permissions.DjangoModelPermissions',
     ]
 }

--- a/foosball/api/views.py
+++ b/foosball/api/views.py
@@ -7,9 +7,9 @@ from foosball.users.models import User
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = ('username', 'email', 'is_staff')
+        fields = ('username',)
 
 
-class UserViewSet(viewsets.ModelViewSet):
-    queryset = User.objects.all()
+class UserViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = User.objects.filter(is_active=True)
     serializer_class = UserSerializer


### PR DESCRIPTION
This PR sets `UserViewSet` as a read-only view and drops few user related field from the API. Authentication is also required for using the API.